### PR TITLE
assay_result_utils test edits

### DIFF
--- a/.github/workflows/check-full-macos.yml
+++ b/.github/workflows/check-full-macos.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [ main, master ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main, master, devel ]
   release:
     types: [ published ]
   workflow_dispatch:

--- a/.github/workflows/check-full.yml
+++ b/.github/workflows/check-full.yml
@@ -7,9 +7,9 @@
 
 on:
   push:
-    branches: [ main, master, 21-implement-function-to-upload-results-from-a-data-frame ]
+    branches: [ main, master, 21-implement-function-to-upload-results-from-a-data-frame]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main, master, devel ]
   release:
     types: [ published ]
   workflow_dispatch:

--- a/tests/testthat/test-assay_result_utils.R
+++ b/tests/testthat/test-assay_result_utils.R
@@ -11,34 +11,53 @@
 test_that('get assay result',{
   assay_result_id <- '908df834-220e-4b59-975b-c21bbbb8191a'
   assay_result_id_list <- list(c(assay_result_id))
-  result <- benchlingr::get_assay_result(assay_result_id = assay_result_id)
+  result <- benchlingr::get_assay_result(
+    assay_result_id = assay_result_id,
+    tenant="hemoshear-dev",
+    api_key=Sys.getenv("BENCHLING_DEV_API_KEY"))
   expect_equal(result[[7]], assay_result_id)
 })
 
 
 test_that('archive_assay_results success', {
   assay_result_ids <- c('908df834-220e-4b59-975b-c21bbbb8191a')
-  archive_result <- benchlingr::archive_assay_results(assay_result_ids = assay_result_ids)
+  archive_result <- benchlingr::archive_assay_results(
+    assay_result_ids = assay_result_ids,
+    tenant="hemoshear-dev",
+    api_key=Sys.getenv("BENCHLING_DEV_API_KEY"))
   assay_result_ids_list <- list(assay_result_ids)
-  testthat::expect_equal(archive_result[[1]], assay_result_ids_list, label = "archive assay result success result.")
+  testthat::expect_equal(archive_result[[1]], assay_result_ids_list, 
+                         label = "archive assay result success result.")
 })
 
 test_that('archive_assay_results fail', {
   assay_result_ids <- c('908df834-220e-4b59-975b-c21bbbb8191a')
   assay_result_ids_list <- list(assay_result_ids)
-  expect_error(benchlingr::archive_assay_results(assay_result_ids = assay_result_ids), regexp = '^.*has already been archived.*$')
+  expect_error(benchlingr::archive_assay_results(
+    assay_result_ids = assay_result_ids,
+    tenant="hemoshear-dev",
+    api_key=Sys.getenv("BENCHLING_DEV_API_KEY")), 
+    regexp = '^.*has already been archived.*$')
 })
 
 test_that('unarchive_assay_results success', {
   assay_result_ids <- c('908df834-220e-4b59-975b-c21bbbb8191a')
-  archive_result <- benchlingr::unarchive_assay_results(assay_result_ids = assay_result_ids)
+  archive_result <- benchlingr::unarchive_assay_results(
+    assay_result_ids = assay_result_ids,
+    tenant="hemoshear-dev",
+    api_key=Sys.getenv("BENCHLING_DEV_API_KEY"))
   assay_result_ids_list <- list(assay_result_ids)
-  testthat::expect_equal(archive_result[[1]], assay_result_ids_list, label = "archive assay result success result.")
+  testthat::expect_equal(archive_result[[1]], assay_result_ids_list, 
+                         label = "archive assay result success result.")
 })
 
 test_that('unarchive_assay_results fail', {
   assay_result_ids <- c('908df834-220e-4b59-975b-c21bbbb8191a')
   assay_result_ids_list <- list(assay_result_ids)
-  expect_error(benchlingr::unarchive_assay_results(assay_result_ids = assay_result_ids), regexp = '^.*has already been unarchived.*$')
+  expect_error(benchlingr::unarchive_assay_results(
+    assay_result_ids = assay_result_ids,
+    tenant="hemoshear-dev",
+    api_key=Sys.getenv("BENCHLING_DEV_API_KEY")),
+    regexp = '^.*has already been unarchived.*$')
 })
 


### PR DESCRIPTION
Changing the assay_result_utils tests to use the 'hemoshear-dev' as the tenant and 'BENCHLING_DEV_API_KEY' environment variable for CI suite.

Unrelated to `assay_result_utils` code, changing the Mac and Ubuntu builds to trigger on PR to `devel`.